### PR TITLE
#7 Polish .srsgem integration for config, logging, and build

### DIFF
--- a/lib/logit.rb
+++ b/lib/logit.rb
@@ -1,21 +1,20 @@
+require 'yaml'
+require_relative 'srsgem_project'
+
 class LogIt
   def self.log_it(string)
-    file_object = File.new("#{Dir.pwd}/.srsgem/build.log", 'a')
+    file_object = File.new(SRSGemProject.file_path('build.log'), 'a')
     file_object.write("#{@datestamp}: #{string} \n")
     file_object.close
   end
 
   def self.log_build
-    path_to_builder_number="#{Dir.pwd}/.srsgem/build-number.yml"
-    puts "path_to_builder_number: #{path_to_builder_number}"
-    build_number_file_reader = File.new(path_to_builder_number, 'r')
+    build_number_path = SRSGemProject.file_path('build-number.yml')
+    build_number_file_reader = File.new(build_number_path, 'r')
     yml = build_number_file_reader.read
-    puts "yml read from build-number.yml: #{yml}"
     build_number_file_reader.close
 
-    yml_str = yml.to_s
-    puts "yml_str: #{yml_str}"
-    yml_obj = YAML.load(yml_str)
+    yml_obj = YAML.load(yml.to_s)
     build_num_string = yml_obj['last_build']['number']
     n = build_num_string.to_i
     @build_number = n.to_s
@@ -23,13 +22,10 @@ class LogIt
     @datestamp = Time.now
     yml_obj['last_build']['date'] = @datestamp.to_s
 
-    # Write the build number to the YAML file which tracks
-    # the build number for number of times SRS has been compiled...
-    build_number_file_writer = File.new("#{Dir.pwd}/.srsgem/build-number.yml", 'w')
+    build_number_file_writer = File.new(build_number_path, 'w')
     build_number_file_writer.write(yml_obj.to_yaml)
     build_number_file_writer.close
 
-    # Write the build number to the log debug log file...
     log_it '================================================'
     log_it "Build Number: #{@build_number}"
     log_it "YAML after mods: #{yml_obj.inspect}"

--- a/lib/srs_builder.rb
+++ b/lib/srs_builder.rb
@@ -12,6 +12,8 @@ require_relative "file_manager"
 require_relative "pandoc_support/pandoc_helper"
 require_relative "srs_header_counter"
 require_relative "logit"
+require_relative "srsgem_config"
+require_relative "srsgem_project"
 require_relative "srs_build_announcer"
 
 class SRSBuilder
@@ -106,10 +108,7 @@ class SRSBuilder
         LogIt.log_it "Converting to SVG: #{item}"
         puml_command = "plantuml #{Dir.pwd}/#{item} -svg"
         %x(#{puml_command})
-        log_file_object = File.new("#{Dir.pwd}/build.log", "a")
-        log_file_object.write(puml_command.to_s)
-        log_file_object.write(NEWLINE)
-        log_file_object.close
+        LogIt.log_it(puml_command)
       end
     end
   end
@@ -153,7 +152,7 @@ class SRSBuilder
   end
 
   def build_timestamp_and_number_markdown
-    yaml_file_reader = File.new("#{Dir.pwd}/.srsgem/#{"build-number.yml"}", "r")
+    yaml_file_reader = File.new(SRSGemProject.file_path('build-number.yml'), "r")
     yml = yaml_file_reader.read
     yaml_file_reader.close
 
@@ -168,7 +167,7 @@ class SRSBuilder
   end
 
   def update_build_num_and_timestamp
-    file_path = "#{Dir.pwd}/.srsgem/build-number.yml"
+    file_path = SRSGemProject.file_path('build-number.yml')
     yaml_obj = YAML.load_file(file_path)
     @build_number = yaml_obj["last_build"]["number"].to_i + 1
     @datestamp = Time.now.to_s
@@ -197,6 +196,7 @@ class SRSBuilder
   # @param [Boolean] build_plantuml whether or not to include PlantUML in the build
   # @return whether the build succeeded
   def build_srs(build_plantuml = true)
+    SRSGemConfig.populate_configs
     SRSBuildAnnouncer.announce_starting_build
     LogIt.log_build
     clear_output

--- a/lib/srsgem_config.rb
+++ b/lib/srsgem_config.rb
@@ -1,4 +1,3 @@
-require_relative 'file_manager'
 require_relative 'srsgem_project'
 require 'yaml'
 
@@ -20,15 +19,12 @@ class SRSGemConfig
   end
 
   def self.populate_configs
-    path = FileManager.yaml_file_path('lib/templates/config.yml')
-    puts path
-    file_reader = File.new(path, "r")
-    yml = file_reader.read
-    file_reader.close
+    path = SRSGemProject.file_path(CONFIG_FILE_NAME)
+    return unless File.exist?(path)
 
-    yml_str = yml.to_s
-    yaml_obj = YAML.load(yml_str)
-    @@configs[:build_plantuml] = yaml_obj[:build_plantuml.to_s]
-    @@configs[:keep_copy_of_plantuml_svg_with_source] = yaml_obj[:keep_copy_of_plantuml_svg_with_source.to_s]
+    yaml_obj = YAML.load_file(path)
+    @@configs[:build_plantuml] = yaml_obj.fetch('build_plantuml', @@configs[:build_plantuml])
+    @@configs[:keep_copy_of_plantuml_svg_with_source] =
+      yaml_obj.fetch('keep_copy_of_plantuml_svg_with_source', @@configs[:keep_copy_of_plantuml_svg_with_source])
   end
 end

--- a/lib/srsgem_project.rb
+++ b/lib/srsgem_project.rb
@@ -1,5 +1,11 @@
 class SRSGemProject
+  PROJECT_DIRECTORY_NAME = '.srsgem'
 
-    PROJECT_DIRECTORY_NAME = '.srsgem'
+  def self.directory_path(base_dir = Dir.pwd)
+    File.join(base_dir.to_s, PROJECT_DIRECTORY_NAME)
+  end
 
+  def self.file_path(filename, base_dir = Dir.pwd)
+    File.join(directory_path(base_dir), filename)
+  end
 end

--- a/test/srs_init_tests.rb
+++ b/test/srs_init_tests.rb
@@ -3,6 +3,9 @@ require "fileutils"
 
 require_relative "../lib/srs_initialization"
 require_relative "../lib/srs_builder"
+require_relative "../lib/srsgem_project"
+require_relative "../lib/logit"
+require "yaml"
 
 require_relative "srs_header_counter_tests"
 
@@ -74,20 +77,36 @@ class TestAdd < Test::Unit::TestCase
   end
 
   def test_srs_build_number_functions_in_dotsrsgem_dir
-    tmp_proj_dir_name = 'tmp_new_srsgem_proj'
-    srs_init_obj = SRSInitialization.new
-    srs_init_obj.init_bare_srsgem_dir(tmp_proj_dir_name)
-    # FileUtils.cd(tmp_proj_dir_name)
-    srs_builder = SRSBuilder.new
-    FileUtils.remove_dir(tmp_proj_dir_name)
+    tmp_proj_dir_name = 'tmp_build_num_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      build_number_path = SRSGemProject.file_path('build-number.yml')
+      initial_number = YAML.load_file(build_number_path)['last_build']['number'].to_i
+
+      SRSBuilder.new.update_build_num_and_timestamp
+
+      updated_number = YAML.load_file(build_number_path)['last_build']['number'].to_i
+      assert_equal(initial_number + 1, updated_number)
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
   end
 
   def test_srs_build_log_can_log_from_within_dotsrsgem_dir
-    # TODO: Finish writing me
-    tmp_proj_dir_name = 'tmp_new_srsgem_proj'
-    srs_init_obj = SRSInitialization.new
-    srs_init_obj.init_bare_srsgem_dir(tmp_proj_dir_name)
-    FileUtils.remove_dir(tmp_proj_dir_name)
+    tmp_proj_dir_name = 'tmp_build_log_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      LogIt.log_it('test build log entry')
+
+      log_path = SRSGemProject.file_path('build.log')
+      assert_true(File.exist?(log_path))
+      assert_match(/test build log entry/, File.read(log_path))
+      assert_false(File.exist?('build.log'))
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
   end
 
   def test_srs_initialization_creates_adr_appendix_template

--- a/test/srsgem_config_tests.rb
+++ b/test/srsgem_config_tests.rb
@@ -1,13 +1,40 @@
 require "test/unit"
+require "fileutils"
+require "yaml"
 
+require_relative "../lib/srs_initialization"
 require_relative "../lib/srsgem_config"
+require_relative "../lib/srsgem_project"
 
 class TestAdd < Test::Unit::TestCase
-  def test_access_configs
-    SRSGemConfig.populate_configs
-    puts "configs: #{SRSGemConfig.configs.to_s}"
-    assert_true(SRSGemConfig.configs[:keep_copy_of_plantuml_svg_with_source])
-    assert_true(SRSGemConfig.configs[:build_plantuml])
+  def test_access_configs_from_project_srsgem_directory
+    tmp_proj_dir_name = 'tmp_config_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      SRSGemConfig.populate_configs
+      assert_true(SRSGemConfig.configs[:keep_copy_of_plantuml_svg_with_source])
+      assert_true(SRSGemConfig.configs[:build_plantuml])
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
+  end
+
+  def test_populate_configs_reads_project_config_file
+    tmp_proj_dir_name = 'tmp_config_override_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      config_path = SRSGemProject.file_path('config.yml')
+      config = YAML.load_file(config_path)
+      config['build_plantuml'] = false
+      File.write(config_path, config.to_yaml)
+
+      SRSGemConfig.populate_configs
+      assert_false(SRSGemConfig.configs[:build_plantuml])
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
   end
 
   def test_access_project_source


### PR DESCRIPTION
Merge develop into branch 7 and finish .srsgem folder behavior: load project config from .srsgem/config.yml at build time, route PlantUML logging through LogIt to .srsgem/build.log, centralize project file paths in SRSGemProject, and complete build-number and build-log init tests.