### PR TITLE
Phase 1: Config-driven file discovery and asset folders

### DIFF
--- a/lib/file_manager.rb
+++ b/lib/file_manager.rb
@@ -1,17 +1,60 @@
+require 'pathname'
+
 class FileManager
+  EXCLUDED_DIRECTORY_NAMES = %w[.srsgem output .git ADRs].freeze
+
   def self.files_in_cur_dir
+    project_files(search_folder: '.', recursive: false)
+  end
+
+  def self.project_files(search_folder: '.', recursive: false)
+    project_root = Dir.pwd.to_s
+    search_root = File.expand_path(search_folder, project_root)
+    return [] unless File.directory?(search_root)
+
     files = []
-    current_dir_path = Dir.pwd.to_s
-    current_dir = Dir.new(current_dir_path)
-    current_dir.each do |file|
-      files.push(file)
+    if recursive
+      collect_files_recursive(search_root, project_root, files)
+    else
+      collect_files_flat(search_root, project_root, files)
     end
-    current_dir.close
     files.sort!
   end
-  
+
   def self.yaml_file_path(yaml_file_name)
-    current_dir_path = Dir.pwd.to_s
-    f_path = current_dir_path + '/' + yaml_file_name
+    File.join(Dir.pwd.to_s, yaml_file_name)
   end
+
+  def self.collect_files_flat(search_root, project_root, files)
+    Dir.children(search_root).sort.each do |entry|
+      next if entry == '.' || entry == '..'
+
+      absolute_path = File.join(search_root, entry)
+      next if File.directory?(absolute_path)
+
+      files << relative_path_for(absolute_path, project_root)
+    end
+  end
+
+  def self.collect_files_recursive(search_root, project_root, files)
+    Dir.children(search_root).sort.each do |entry|
+      next if entry == '.' || entry == '..'
+
+      absolute_path = File.join(search_root, entry)
+      if File.directory?(absolute_path)
+        next if EXCLUDED_DIRECTORY_NAMES.include?(entry)
+
+        collect_files_recursive(absolute_path, project_root, files)
+      else
+        files << relative_path_for(absolute_path, project_root)
+      end
+    end
+  end
+
+  def self.relative_path_for(absolute_path, project_root)
+    path = Pathname.new(absolute_path).relative_path_from(Pathname.new(project_root)).to_s
+    path.tr('\\', '/')
+  end
+
+  private_class_method :collect_files_flat, :collect_files_recursive, :relative_path_for
 end

--- a/lib/srs_builder.rb
+++ b/lib/srs_builder.rb
@@ -36,6 +36,44 @@ class SRSBuilder
     @header_counter = SRSHeaderCounter.new
   end
 
+  def project_file_path(relative_path)
+    File.join(Dir.pwd, relative_path)
+  end
+
+  def markdown_source_files
+    FileManager.project_files(
+      search_folder: SRSGemConfig.configs[:markdown_search_folder],
+      recursive: SRSGemConfig.configs[:markdown_search_is_recursive]
+    )
+  end
+
+  def yaml_mapping_source_files
+    FileManager.project_files(
+      search_folder: SRSGemConfig.configs[:yaml_mappings_search_folder],
+      recursive: SRSGemConfig.configs[:yaml_mappings_search_is_recursive]
+    )
+  end
+
+  def assembly_source_files
+    files = []
+    markdown_source_files.each { |item| files << item if markdown_source_file?(item) }
+    yaml_mapping_source_files.each { |item| files << item if yaml_mapping_source_file?(item) }
+    files.uniq.sort
+  end
+
+  def markdown_source_file?(item)
+    /.*\.md\z/i =~ item || /.*\.markdown\z/i =~ item
+  end
+
+  def yaml_mapping_source_file?(item)
+    (/.*\.yml\z/i =~ item || /.*\.yaml\z/i =~ item) &&
+      !item.eql?("title-template.yml") && !item.eql?("build-number-template.yml")
+  end
+
+  def readme_file?(item)
+    File.basename(item).upcase.eql?("README.MD") || File.basename(item).upcase.eql?("README.MARKDOWN")
+  end
+
   # Replaces header hash tags with numbered header hash tags
   def numbered_headers(markdown_string)
     new_string = ""
@@ -49,18 +87,14 @@ class SRSBuilder
 
   # Gets all the YAML mapping files locating the same directory as the markdown
   def yaml_file_names
-    #TODO: write me
-    files = FileManager.files_in_cur_dir
     yaml_file_names = Array.new
-    files.each do |item|
+    yaml_mapping_source_files.each do |item|
+      next unless yaml_mapping_source_file?(item)
+
       LogIt.log_it "found a .yaml extension!" if /.*\.yaml/ =~ item
-      if (/.*\.yml/ =~ item || /.*\.yaml/ =~ item) &&
-         !(item.eql?("title-template.yml")) && !(item.eql?("build-number-template.yml"))
-        file = File.open("#{Dir.pwd}/#{item}")
-        LogIt.log_it "PUSHING YAML FILE: #{item}"
-        LogIt.log_it "Compiling YAML mapping #{item}..."
-        yaml_file_names.push(item)
-      end
+      LogIt.log_it "PUSHING YAML FILE: #{item}"
+      LogIt.log_it "Compiling YAML mapping #{item}..."
+      yaml_file_names.push(item)
     end
     yaml_file_names
   end
@@ -68,26 +102,25 @@ class SRSBuilder
   # Assembles all markdown into a single string
   def assembled_markdown
     markdown_string = ""
-    files = FileManager.files_in_cur_dir
-    files.each do |item|
-      if (/.*\.md/ =~ item || /.*\.markdown/ =~ item) &&
-         !item.upcase.eql?("README.MD") && !item.upcase.eql?("README.MARKDOWN")
-        file = File.open("#{Dir.pwd}/#{item}")
+    assembly_source_files.each do |item|
+      if markdown_source_file?(item) && !readme_file?(item)
+        file = File.open(project_file_path(item))
         LogIt.log_it "Compiling #{item}..."
         text = "" "
 
 #{file.read}
 
 " ""
+        file.close
         markdown_string = "" "
 #{markdown_string}" + "#{NEWLINE}#{NEWLINE} #{text}
 
 [&#x21e7; Table of Contents](\#title-block-header)
 
 " ""
-      elsif (/.*\.yml/ =~ item || /.*\.yaml/ =~ item) && !(item.eql?("title-template.yml")) && !(item.eql?("build-number-template.yml"))
+      elsif yaml_mapping_source_file?(item)
         LogIt.log_it "Transpiling YAML mapping #{item} to markdown"
-        yaml_file_reader = File.new("#{Dir.pwd}/#{item}", "r")
+        yaml_file_reader = File.new(project_file_path(item), "r")
         yml = yaml_file_reader.read
         yaml_file_reader.close
 
@@ -101,15 +134,14 @@ class SRSBuilder
   end
 
   def export_svgs_from_plantuml
-    files = FileManager.files_in_cur_dir
     LogIt.log_it "Searching for PlantUML files..."
-    files.each do |item|
-      if /.*\.puml/ =~ item
-        LogIt.log_it "Converting to SVG: #{item}"
-        puml_command = "plantuml #{Dir.pwd}/#{item} -svg"
-        %x(#{puml_command})
-        LogIt.log_it(puml_command)
-      end
+    markdown_source_files.each do |item|
+      next unless /.*\.puml\z/i =~ item
+
+      LogIt.log_it "Converting to SVG: #{item}"
+      puml_command = "plantuml #{project_file_path(item)} -svg"
+      %x(#{puml_command})
+      LogIt.log_it(puml_command)
     end
   end
 
@@ -121,18 +153,20 @@ class SRSBuilder
 
   def copy_resources
     LogIt.log_it("Begin copying resources...")
-    output_dir = "#{Dir.pwd}/output/"
-    cpy_cmd = "cp "
-    Dir.foreach(Dir.pwd.to_s) do |item|
+    output_root = File.join(Dir.pwd, 'output')
+
+    markdown_source_files.each do |item|
       RSRC_RECOGNITION_HASH.each do |subdir, regex_strings|
         regex_strings.each do |pattern|
-          next unless Regexp.new(pattern) =~ item
+          next unless Regexp.new(pattern) =~ File.basename(item)
 
-          FileUtils.mkdir_p(output_dir + subdir.to_s) unless File.directory?(File.join("output", subdir.to_s))
-          FileUtils.copy(item, File.join(File.join("output", subdir.to_s), item.to_s))
-          command = cpy_cmd + "#{item} " + output_dir + subdir.to_s + "/" + item.to_s
-          LogIt.log_it "copying resource #{item} with '#{command}'..."
-          `#{command}`
+          relative_dir = File.dirname(item)
+          relative_dir = '' if relative_dir == '.'
+          destination_dir = File.join(output_root, subdir.to_s, relative_dir)
+          FileUtils.mkdir_p(destination_dir)
+          destination_path = File.join(destination_dir, File.basename(item))
+          FileUtils.copy(project_file_path(item), destination_path)
+          LogIt.log_it "copying resource #{item} to #{destination_path}..."
         end
       end
     end
@@ -140,13 +174,13 @@ class SRSBuilder
   end
 
   def adjust_html_output_css_filepath
-    srs_html_file = File.new("#{Dir.pwd}/#{OUTPUT_LOCATION}", "r")
+    srs_html_file = File.new(File.join(Dir.pwd, OUTPUT_LOCATION), "r")
     srs_html_file_contents = srs_html_file.read
     srs_html_file.close
 
     srs_html_file_contents.gsub!(/srs.css/, "css/srs.css")
 
-    srs_html_file_w = File.new("#{Dir.pwd}/#{OUTPUT_LOCATION}", "w")
+    srs_html_file_w = File.new(File.join(Dir.pwd, OUTPUT_LOCATION), "w")
     srs_html_file_w.write(srs_html_file_contents)
     srs_html_file_w.close
   end

--- a/lib/srs_initialization.rb
+++ b/lib/srs_initialization.rb
@@ -7,6 +7,7 @@ require_relative 'srsgem_project'
 # with a bare bones SRSGem setup
 class SRSInitialization
   ADR_STATUS_FOLDERS = %w[proposed accepted deprecated superseded].freeze
+  ASSET_SUBFOLDERS = %w[markdown diagrams].freeze
 
   STARTER_ADR_FILENAME = 'ADR-001-[title].md'
 
@@ -115,6 +116,7 @@ class SRSInitialization
     srsgem_project_dir = Dir.mkdir("#{target_dir}/#{SRSGemProject::PROJECT_DIRECTORY_NAME}")
 
     create_adr_directory_structure(target_dir)
+    create_asset_subfolders(target_dir)
 
     # BREAKING CHANGES
     # 1. config.yml should be moved into the .srsgem folder
@@ -138,5 +140,11 @@ class SRSInitialization
 
     starter_adr_path = "#{adr_root}/proposed/#{STARTER_ADR_FILENAME}"
     populate_file_with_contents(starter_adr_path, STARTER_ADR_CONTENT)
+  end
+
+  def create_asset_subfolders(target_dir)
+    ASSET_SUBFOLDERS.each do |folder|
+      FileUtils.mkdir_p(File.join(target_dir, folder))
+    end
   end
 end

--- a/lib/srsgem_config.rb
+++ b/lib/srsgem_config.rb
@@ -7,7 +7,11 @@ class SRSGemConfig
 
   @@configs = {
     :build_plantuml => true,
-    :keep_copy_of_plantuml_svg_with_source => true
+    :keep_copy_of_plantuml_svg_with_source => true,
+    :markdown_search_folder => '.',
+    :markdown_search_is_recursive => false,
+    :yaml_mappings_search_folder => '.',
+    :yaml_mappings_search_is_recursive => false
   }
 
   def self.configs
@@ -26,5 +30,13 @@ class SRSGemConfig
     @@configs[:build_plantuml] = yaml_obj.fetch('build_plantuml', @@configs[:build_plantuml])
     @@configs[:keep_copy_of_plantuml_svg_with_source] =
       yaml_obj.fetch('keep_copy_of_plantuml_svg_with_source', @@configs[:keep_copy_of_plantuml_svg_with_source])
+    @@configs[:markdown_search_folder] =
+      yaml_obj.fetch('markdown_search_folder', @@configs[:markdown_search_folder])
+    @@configs[:markdown_search_is_recursive] =
+      yaml_obj.fetch('markdown_search_is_recursive', @@configs[:markdown_search_is_recursive])
+    @@configs[:yaml_mappings_search_folder] =
+      yaml_obj.fetch('yaml_mappings_search_folder', @@configs[:yaml_mappings_search_folder])
+    @@configs[:yaml_mappings_search_is_recursive] =
+      yaml_obj.fetch('yaml_mappings_search_is_recursive', @@configs[:yaml_mappings_search_is_recursive])
   end
 end

--- a/test/file_manager_tests.rb
+++ b/test/file_manager_tests.rb
@@ -1,0 +1,51 @@
+require "test/unit"
+require "fileutils"
+
+require_relative "../lib/file_manager"
+
+class FileManagerTests < Test::Unit::TestCase
+  def setup
+    @tmp_dir = "tmp_file_manager_proj"
+    FileUtils.mkdir_p(@tmp_dir)
+    FileUtils.mkdir_p(File.join(@tmp_dir, "markdown"))
+    FileUtils.mkdir_p(File.join(@tmp_dir, "diagrams", "nested"))
+    FileUtils.mkdir_p(File.join(@tmp_dir, ".srsgem"))
+    FileUtils.mkdir_p(File.join(@tmp_dir, "output"))
+    FileUtils.touch(File.join(@tmp_dir, "001-root.md"))
+    FileUtils.touch(File.join(@tmp_dir, "markdown", "002-nested.md"))
+    FileUtils.touch(File.join(@tmp_dir, "diagrams", "nested", "003-deep.puml"))
+    FileUtils.touch(File.join(@tmp_dir, ".srsgem", "config.yml"))
+  end
+
+  def teardown
+    FileUtils.remove_dir(@tmp_dir) if Dir.exist?(@tmp_dir)
+  end
+
+  def test_project_files_flat_scan
+    Dir.chdir(@tmp_dir) do
+      files = FileManager.project_files(search_folder: '.', recursive: false)
+      assert_equal(["001-root.md"], files)
+    end
+  end
+
+  def test_project_files_recursive_scan_in_lex_order
+    Dir.chdir(@tmp_dir) do
+      files = FileManager.project_files(search_folder: '.', recursive: true)
+      assert_equal(
+        ["001-root.md", "diagrams/nested/003-deep.puml", "markdown/002-nested.md"],
+        files
+      )
+    end
+  end
+
+  def test_project_files_excludes_srsgem_and_output
+    Dir.chdir(@tmp_dir) do
+      files = FileManager.project_files(search_folder: '.', recursive: true)
+      refute_includes(files, ".srsgem/config.yml")
+      files.each do |file|
+        refute_match(%r{\A\.srsgem/}, file)
+        refute_match(%r{\Aoutput/}, file)
+      end
+    end
+  end
+end

--- a/test/srs_init_tests.rb
+++ b/test/srs_init_tests.rb
@@ -127,6 +127,17 @@ class TestAdd < Test::Unit::TestCase
     FileUtils.remove_dir(tmp_proj_dir_name)
   end
 
+  def test_srs_initialization_creates_asset_subfolders
+    tmp_proj_dir_name = 'tmp_asset_folders_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    SRSInitialization::ASSET_SUBFOLDERS.each do |folder|
+      assert_true(Dir.exist?("#{tmp_proj_dir_name}/#{folder}"))
+    end
+
+    FileUtils.remove_dir(tmp_proj_dir_name)
+  end
+
   def test_srs_initialization_creates_adr_directory_structure
     tmp_proj_dir_name = 'tmp_adr_dirs_proj'
     srs_init_obj = SRSInitialization.new

--- a/test/srsgem_config_tests.rb
+++ b/test/srsgem_config_tests.rb
@@ -37,6 +37,25 @@ class TestAdd < Test::Unit::TestCase
     FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
   end
 
+  def test_populate_configs_reads_search_path_settings
+    tmp_proj_dir_name = 'tmp_search_config_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      config_path = SRSGemProject.file_path('config.yml')
+      config = YAML.load_file(config_path)
+      config['markdown_search_is_recursive'] = true
+      config['yaml_mappings_search_is_recursive'] = true
+      File.write(config_path, config.to_yaml)
+
+      SRSGemConfig.populate_configs
+      assert_true(SRSGemConfig.configs[:markdown_search_is_recursive])
+      assert_true(SRSGemConfig.configs[:yaml_mappings_search_is_recursive])
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
+  end
+
   def test_access_project_source
     assert_true(SRSGemConfig.report_project_directory.eql? '.srsgem')
   end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -13,3 +13,6 @@ require_relative "srs_section_markdown_tag_tests"
 
 # test SRSGemConfig
 require_relative "srsgem_config_tests"
+
+# test FileManager
+require_relative "file_manager_tests"


### PR DESCRIPTION
## Summary

Phase 1 from the open-issues roadmap — implements the file discovery behavior already specified in `.srsgem/config.yml`.

Closes #4, #5, #33

## Changes

- **FileManager** — `project_files` with flat/recursive scan, lex order, excludes `.srsgem`, `output`, `.git`, `ADRs`
- **SRSGemConfig** — loads `markdown_search_*` and `yaml_mappings_search_*` settings at build time
- **SRSBuilder** — uses config-driven discovery for markdown assembly, PlantUML export, YAML mappings, and nested resource copy
- **SRSInitialization** — scaffolds `markdown/` and `diagrams/` asset folders at init
- **Tests** — FileManager scan tests, asset folder init test, search config load test

## Notes

- Folds in #15 (`File.join`) for paths touched in this change
- Does not merge stale `feature/folder-organization`; rebuilt on current `develop`

## Test plan

- [x] `ruby ./test/tests.rb` (25 tests, all passing)

## Dependency

Parent PR for Phase 3 (#3), Phase 6 (#2), and Phase 7 (#26). Please merge before those phases proceed.