### PR TITLE
Phase 2: Configurable PlantUML jar and Pandoc command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 ## Prerequisites
 
   - Install the [Ruby](https://www.ruby-lang.org/) programming language.
-  - Install [PlantUML](https://plantuml.com/starting) and ensure the `plantuml` command is in your `PATH`.
-      - (Option to select location of `.jar` file for this is coming soon!)
+  - Install [PlantUML](https://plantuml.com/starting) and ensure the `plantuml` command is in your `PATH`, or set `plantuml_jar_path` in your project's `.srsgem/config.yml` to use a specific `.jar` file.
   - Install [Pandoc](https://www.pandoc.org/) and ensure the `pandoc` command is in your `PATH`.
 
 ## Installation

--- a/lib/pandoc_support/pandoc_helper.rb
+++ b/lib/pandoc_support/pandoc_helper.rb
@@ -1,3 +1,5 @@
+require_relative '../srsgem_config'
+
 class PandocHelper
 
   DEFAULT_PANDOC_COMMAND = 'pandoc'
@@ -10,9 +12,14 @@ class PandocHelper
   end
 
   def self.pandoc_build_command_prefix=(pfx)
-    @@double_at_symbol = pfx
+    @@pandoc_build_command_prefix = pfx
   end
 
+  def self.configure_from_project_config
+    command = SRSGemConfig.configs[:pandoc_command]
+    @@pandoc_build_command = command
+    @@pandoc_build_command_prefix = "#{command} -s -o "
+  end
 
   CSS_TERM = 'css'
   CSS_TITLE = 'srs'

--- a/lib/srs_builder.rb
+++ b/lib/srs_builder.rb
@@ -106,7 +106,7 @@ class SRSBuilder
     files.each do |item|
       if /.*\.puml/ =~ item
         LogIt.log_it "Converting to SVG: #{item}"
-        puml_command = "plantuml #{Dir.pwd}/#{item} -svg"
+        puml_command = SRSGemConfig.plantuml_command_for("#{Dir.pwd}/#{item}")
         %x(#{puml_command})
         LogIt.log_it(puml_command)
       end
@@ -197,6 +197,7 @@ class SRSBuilder
   # @return whether the build succeeded
   def build_srs(build_plantuml = true)
     SRSGemConfig.populate_configs
+    PandocHelper.configure_from_project_config
     SRSBuildAnnouncer.announce_starting_build
     LogIt.log_build
     clear_output

--- a/lib/srs_builder.rb
+++ b/lib/srs_builder.rb
@@ -198,6 +198,7 @@ class SRSBuilder
   # @return whether the build succeeded
   def build_srs(build_plantuml = true)
     SRSGemConfig.populate_configs
+    PandocHelper.configure_from_project_config
     SRSIdManager.ensure_ids_file
     SRSBuildAnnouncer.announce_starting_build
     LogIt.log_build

--- a/lib/srsgem_config.rb
+++ b/lib/srsgem_config.rb
@@ -7,7 +7,10 @@ class SRSGemConfig
 
   @@configs = {
     :build_plantuml => true,
-    :keep_copy_of_plantuml_svg_with_source => true
+    :keep_copy_of_plantuml_svg_with_source => true,
+    :pandoc_command => 'pandoc',
+    :plantuml_jar_path => '',
+    :plantuml_command => 'plantuml'
   }
 
   def self.configs
@@ -26,5 +29,28 @@ class SRSGemConfig
     @@configs[:build_plantuml] = yaml_obj.fetch('build_plantuml', @@configs[:build_plantuml])
     @@configs[:keep_copy_of_plantuml_svg_with_source] =
       yaml_obj.fetch('keep_copy_of_plantuml_svg_with_source', @@configs[:keep_copy_of_plantuml_svg_with_source])
+    @@configs[:pandoc_command] = yaml_obj.fetch('pandoc_command', @@configs[:pandoc_command])
+    @@configs[:plantuml_jar_path] = yaml_obj.fetch('plantuml_jar_path', @@configs[:plantuml_jar_path]).to_s
+    @@configs[:plantuml_command] = yaml_obj.fetch('plantuml_command', @@configs[:plantuml_command])
+  end
+
+  def self.plantuml_command_for(input_path, output_flag = '-svg')
+    if plantuml_jar_path_configured?
+      "java -jar #{@@configs[:plantuml_jar_path]} #{input_path} #{output_flag}"
+    else
+      "#{@@configs[:plantuml_command]} #{input_path} #{output_flag}"
+    end
+  end
+
+  def self.plantuml_version_command
+    if plantuml_jar_path_configured?
+      "java -jar #{@@configs[:plantuml_jar_path]} -version"
+    else
+      "#{@@configs[:plantuml_command]} -version"
+    end
+  end
+
+  def self.plantuml_jar_path_configured?
+    !@@configs[:plantuml_jar_path].to_s.strip.empty?
   end
 end

--- a/lib/srsgem_config.rb
+++ b/lib/srsgem_config.rb
@@ -8,6 +8,9 @@ class SRSGemConfig
   @@configs = {
     :build_plantuml => true,
     :keep_copy_of_plantuml_svg_with_source => true,
+    :pandoc_command => 'pandoc',
+    :plantuml_jar_path => '',
+    :plantuml_command => 'plantuml',
     # Stable ID related (loaded for #47 and future #48)
     :auto_assign_ids_on_build => false,
     :auto_assign_levels => [1, 2, 3],
@@ -30,6 +33,9 @@ class SRSGemConfig
     @@configs[:build_plantuml] = yaml_obj.fetch('build_plantuml', @@configs[:build_plantuml])
     @@configs[:keep_copy_of_plantuml_svg_with_source] =
       yaml_obj.fetch('keep_copy_of_plantuml_svg_with_source', @@configs[:keep_copy_of_plantuml_svg_with_source])
+    @@configs[:pandoc_command] = yaml_obj.fetch('pandoc_command', @@configs[:pandoc_command])
+    @@configs[:plantuml_jar_path] = yaml_obj.fetch('plantuml_jar_path', @@configs[:plantuml_jar_path]).to_s
+    @@configs[:plantuml_command] = yaml_obj.fetch('plantuml_command', @@configs[:plantuml_command])
 
     # Stable IDs config (partial support for #47; full in #48)
     if yaml_obj.key?('auto_assign_ids_on_build')
@@ -42,5 +48,25 @@ class SRSGemConfig
     if yaml_obj.key?('warn_on_missing_ids')
       @@configs[:warn_on_missing_ids] = !!yaml_obj['warn_on_missing_ids']
     end
+  end
+
+  def self.plantuml_command_for(input_path, output_flag = '-svg')
+    if plantuml_jar_path_configured?
+      "java -jar #{@@configs[:plantuml_jar_path]} #{input_path} #{output_flag}"
+    else
+      "#{@@configs[:plantuml_command]} #{input_path} #{output_flag}"
+    end
+  end
+
+  def self.plantuml_version_command
+    if plantuml_jar_path_configured?
+      "java -jar #{@@configs[:plantuml_jar_path]} -version"
+    else
+      "#{@@configs[:plantuml_command]} -version"
+    end
+  end
+
+  def self.plantuml_jar_path_configured?
+    !@@configs[:plantuml_jar_path].to_s.strip.empty?
   end
 end

--- a/lib/srsgem_linter.rb
+++ b/lib/srsgem_linter.rb
@@ -1,4 +1,6 @@
 require_relative 'srs_initialization'
+require_relative 'srsgem_config'
+require_relative 'srsgem_project'
 
 # Helps ensure SRS source directories have all that's needed to build
 # an SRS using SRSGem. Also checks for system dependencies.
@@ -28,8 +30,9 @@ class SRSGemLinter
   end
 
   def self.check_plantuml
-    pandoc_version_cmd_output = %x(plantuml -version)
-    if "#{pandoc_version_cmd_output}".include? "PlantUML version"
+    SRSGemConfig.populate_configs if File.exist?(SRSGemProject.file_path('config.yml'))
+    plantuml_version_cmd_output = %x(#{SRSGemConfig.plantuml_version_command})
+    if "#{plantuml_version_cmd_output}".include? "PlantUML version"
       puts "#{PASSED} PlantUML installed"
     else
       puts "#{FAILED} PlantUML not found."

--- a/lib/templates/config.yml
+++ b/lib/templates/config.yml
@@ -38,6 +38,11 @@ keep_copy_of_plantuml_svg_with_source: true
 # run the correct build of pandoc.
 pandoc_command: 'pandoc'
 
+# PlantUML invocation. Prefer plantuml_jar_path when set; otherwise
+# plantuml_command is used (must be available on PATH).
+plantuml_jar_path: ''
+plantuml_command: 'plantuml'
+
 
 ################################################################################
 # Stable IDs (Traceability)

--- a/lib/templates/config.yml
+++ b/lib/templates/config.yml
@@ -37,3 +37,8 @@ keep_copy_of_plantuml_svg_with_source: true
 # The command or executable to use in order to
 # run the correct build of pandoc.
 pandoc_command: 'pandoc'
+
+# PlantUML invocation. Prefer plantuml_jar_path when set; otherwise
+# plantuml_command is used (must be available on PATH).
+plantuml_jar_path: ''
+plantuml_command: 'plantuml'

--- a/test/srsgem_config_tests.rb
+++ b/test/srsgem_config_tests.rb
@@ -37,6 +37,37 @@ class TestAdd < Test::Unit::TestCase
     FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
   end
 
+  def test_plantuml_command_uses_jar_when_configured
+    tmp_proj_dir_name = 'tmp_plantuml_jar_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      config_path = SRSGemProject.file_path('config.yml')
+      config = YAML.load_file(config_path)
+      config['plantuml_jar_path'] = '/opt/plantuml/plantuml.jar'
+      File.write(config_path, config.to_yaml)
+
+      SRSGemConfig.populate_configs
+      command = SRSGemConfig.plantuml_command_for('/tmp/example.puml')
+      assert_equal('java -jar /opt/plantuml/plantuml.jar /tmp/example.puml -svg', command)
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
+  end
+
+  def test_plantuml_command_uses_path_command_by_default
+    tmp_proj_dir_name = 'tmp_plantuml_default_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      SRSGemConfig.populate_configs
+      command = SRSGemConfig.plantuml_command_for('/tmp/example.puml')
+      assert_equal('plantuml /tmp/example.puml -svg', command)
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
+  end
+
   def test_access_project_source
     assert_true(SRSGemConfig.report_project_directory.eql? '.srsgem')
   end


### PR DESCRIPTION
## Summary

Phase 2 from the open-issues roadmap.

Closes #1

## Changes

- **config.yml** — adds `plantuml_jar_path` and `plantuml_command` settings
- **SRSGemConfig** — builds PlantUML and version-check commands from config
- **SRSBuilder** — uses configured PlantUML invocation during SVG export
- **SRSGemLinter** — respects jar/command config when checking PlantUML
- **PandocHelper** — wires `pandoc_command` from project config at build time
- **README** — documents jar path option (replaces "coming soon")

## Test plan

- [x] `ruby ./test/tests.rb` (22 tests, all passing)

## Dependency

Parent PR for Phase 3 (#3 lint-at-build). Can merge independently of Phase 1, but Phase 3 should wait for both Phase 1 and Phase 2.