### PR TITLE
Implement #41: Persist last-used ID counters similar to build-number.yml

### DIFF
--- a/lib/srs_builder.rb
+++ b/lib/srs_builder.rb
@@ -15,6 +15,7 @@ require_relative "logit"
 require_relative "srsgem_config"
 require_relative "srsgem_project"
 require_relative "srs_build_announcer"
+require_relative "srs_id_manager"
 
 class SRSBuilder
   attr_accessor :header_counter
@@ -197,6 +198,7 @@ class SRSBuilder
   # @return whether the build succeeded
   def build_srs(build_plantuml = true)
     SRSGemConfig.populate_configs
+    SRSIdManager.ensure_ids_file
     SRSBuildAnnouncer.announce_starting_build
     LogIt.log_build
     clear_output

--- a/lib/srs_id_manager.rb
+++ b/lib/srs_id_manager.rb
@@ -1,0 +1,116 @@
+require "yaml"
+require "fileutils"
+
+require_relative "srsgem_project"
+
+# Manages persistent storage of the last-used ID numbers per namespace/prefix
+# (e.g. BR, TS, ADR, DIAG, ...). Stored in .srsgem/ids.yml similar to build-number.yml.
+#
+# Provides a reusable API for both the future `srsgem ids assign` command
+# and optional auto-assignment during `srsgem build`.
+class SRSIdManager
+  IDS_FILENAME = "ids.yml"
+
+  # Supported prefixes (can be extended in future; new prefixes will auto-start at 1)
+  DEFAULT_PREFIXES = %w[BR TS BC TC DIAG BGT TGT ADR BDR REF].freeze
+
+  def self.ids_file_path(base_dir = Dir.pwd)
+    SRSGemProject.file_path(IDS_FILENAME, base_dir)
+  end
+
+  # Loads the last_ids map from disk. Returns a hash like { "BR" => 5, "ADR" => 1 }
+  # Returns empty hash if file does not exist.
+  def self.load_ids(base_dir = Dir.pwd)
+    path = ids_file_path(base_dir)
+    return {} unless File.exist?(path)
+
+    begin
+      yaml = YAML.load_file(path) || {}
+      ids = yaml["last_ids"] || {}
+      # Normalize keys to strings
+      ids.transform_keys { |k| k.to_s.upcase }
+    rescue
+      {}
+    end
+  end
+
+  # Saves the given last_ids hash back to disk.
+  def self.save_ids(ids_hash, base_dir = Dir.pwd)
+    path = ids_file_path(base_dir)
+    dir = File.dirname(path)
+    FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+
+    # Normalize and only keep known or new string keys with integer values
+    normalized = {}
+    ids_hash.each do |k, v|
+      pfx = k.to_s.upcase.sub(/-$/, "")
+      normalized[pfx] = v.to_i
+    end
+
+    data = { "last_ids" => normalized }
+    File.open(path, "w") { |file| file.write(data.to_yaml) }
+  end
+
+  # Returns the next full ID string for the prefix (e.g. "BR-7") and
+  # immediately persists the incremented counter.
+  #
+  # If the prefix has never been seen, it starts at 1.
+  def self.next_id(prefix, base_dir = Dir.pwd)
+    pfx = normalize_prefix(prefix)
+    ids = load_ids(base_dir)
+
+    # Seed defaults on first use if completely empty
+    if ids.empty? && !File.exist?(ids_file_path(base_dir))
+      ids = default_last_ids
+    end
+
+    current = ids[pfx] || 0
+    next_number = current + 1
+    ids[pfx] = next_number
+
+    save_ids(ids, base_dir)
+    format_id(pfx, next_number)
+  end
+
+  # Returns the last assigned number for the prefix (0 if never assigned).
+  def self.last_number(prefix, base_dir = Dir.pwd)
+    pfx = normalize_prefix(prefix)
+    ids = load_ids(base_dir)
+    ids[pfx] || 0
+  end
+
+  # Explicitly sets the last used number for a prefix (useful for bootstrapping
+  # from existing files that already contain manually assigned IDs).
+  def self.set_last(prefix, number, base_dir = Dir.pwd)
+    pfx = normalize_prefix(prefix)
+    ids = load_ids(base_dir)
+    ids[pfx] = number.to_i
+    save_ids(ids, base_dir)
+    number.to_i
+  end
+
+  # Returns a formatted ID string. Currently "PREFIX-N" (no zero padding to
+  # match the examples in the stable ID issues). Can be adjusted later.
+  def self.format_id(prefix, number)
+    pfx = normalize_prefix(prefix)
+    "#{pfx}-#{number}"
+  end
+
+  # Ensures the ids.yml file exists with default seeds (called implicitly on first next_id
+  # or can be called proactively).
+  def self.ensure_ids_file(base_dir = Dir.pwd)
+    path = ids_file_path(base_dir)
+    return if File.exist?(path)
+
+    save_ids(default_last_ids, base_dir)
+  end
+
+  # The default map used when creating a fresh ids.yml
+  def self.default_last_ids
+    DEFAULT_PREFIXES.each_with_object({}) { |p, h| h[p] = 0 }
+  end
+
+  private_class_method def self.normalize_prefix(pfx)
+    pfx.to_s.upcase.sub(/-$/, "")
+  end
+end

--- a/lib/srs_initialization.rb
+++ b/lib/srs_initialization.rb
@@ -121,6 +121,7 @@ class SRSInitialization
     FileUtils.mv("#{target_dir}/config.yml", "#{target_dir}/.srsgem/config.yml")
     FileUtils.mv("#{target_dir}/build-number.yml", "#{target_dir}/.srsgem/build-number.yml")
     FileUtils.mv("#{target_dir}/build.log", "#{target_dir}/.srsgem/build.log")
+    FileUtils.mv("#{target_dir}/ids.yml", "#{target_dir}/.srsgem/ids.yml")
 
 
 

--- a/lib/templates/config.yml
+++ b/lib/templates/config.yml
@@ -37,3 +37,13 @@ keep_copy_of_plantuml_svg_with_source: true
 # The command or executable to use in order to
 # run the correct build of pandoc.
 pandoc_command: 'pandoc'
+
+
+################################################################################
+# Stable IDs (Traceability)
+#
+# Last-used counters per namespace (BR, TS, ADR, DIAG, etc.) are stored in
+# .srsgem/ids.yml (see SRSIdManager). This file is created on `srsgem init`.
+#
+# Config options for auto-assign and warnings are planned (issues #48, #46, #47).
+################################################################################

--- a/lib/templates/ids-template.yml
+++ b/lib/templates/ids-template.yml
@@ -1,0 +1,12 @@
+---
+last_ids:
+  BR: 0
+  TS: 0
+  BC: 0
+  TC: 0
+  DIAG: 0
+  BGT: 0
+  TGT: 0
+  ADR: 0
+  BDR: 0
+  REF: 0

--- a/test/srs_init_tests.rb
+++ b/test/srs_init_tests.rb
@@ -5,6 +5,7 @@ require_relative "../lib/srs_initialization"
 require_relative "../lib/srs_builder"
 require_relative "../lib/srsgem_project"
 require_relative "../lib/logit"
+require_relative "../lib/srs_id_manager"
 require "yaml"
 
 require_relative "srs_header_counter_tests"
@@ -73,6 +74,7 @@ class TestAdd < Test::Unit::TestCase
     assert_true(File.exist?("#{tmp_proj_dir_name}/.srsgem/config.yml"))
     assert_true(File.exist?("#{tmp_proj_dir_name}/.srsgem/build-number.yml"))
     assert_true(File.exist?("#{tmp_proj_dir_name}/.srsgem/build.log"))
+    assert_true(File.exist?("#{tmp_proj_dir_name}/.srsgem/ids.yml"))
     FileUtils.remove_dir(tmp_proj_dir_name)
   end
 
@@ -143,4 +145,43 @@ class TestAdd < Test::Unit::TestCase
     FileUtils.remove_dir(tmp_proj_dir_name)
   end
 
+  def test_srs_id_manager_persists_counters_in_dotsrsgem_dir
+    tmp_proj_dir_name = 'tmp_id_counters_proj'
+    SRSInitialization.new.init_bare_srsgem_dir(tmp_proj_dir_name)
+
+    Dir.chdir(tmp_proj_dir_name) do
+      # Fresh project should have 0 for all prefixes
+      assert_equal(0, SRSIdManager.last_number("BR"))
+      assert_equal(0, SRSIdManager.last_number("ADR"))
+      assert_equal(0, SRSIdManager.last_number("DIAG"))
+
+      # next_id should return formatted string and increment
+      first_br = SRSIdManager.next_id("BR")
+      assert_equal("BR-1", first_br)
+      assert_equal(1, SRSIdManager.last_number("BR"))
+
+      second_br = SRSIdManager.next_id("BR")
+      assert_equal("BR-2", second_br)
+      assert_equal(2, SRSIdManager.last_number("br")) # case insensitive prefix
+
+      # Different prefix
+      first_adr = SRSIdManager.next_id("ADR")
+      assert_equal("ADR-1", first_adr)
+
+      # Verify file persisted correctly
+      ids_path = SRSGemProject.file_path("ids.yml")
+      loaded = YAML.load_file(ids_path)["last_ids"]
+      assert_equal(2, loaded["BR"])
+      assert_equal(1, loaded["ADR"])
+
+      # Also test set_last (for future bootstrap use)
+      SRSIdManager.set_last("TS", 42)
+      assert_equal(42, SRSIdManager.last_number("TS"))
+      assert_equal("TS-43", SRSIdManager.next_id("TS"))
+    end
+  ensure
+    FileUtils.remove_dir(tmp_proj_dir_name) if Dir.exist?(tmp_proj_dir_name)
+  end
+
 end
+


### PR DESCRIPTION
## Summary
Implements GitHub issue #41 as the foundational persistence layer for the Stable / Immutable Traceable IDs milestone.

Introduces `.srsgem/ids.yml` (modeled directly after the existing `build-number.yml` pattern) and `SRSIdManager` to track the highest ID used per namespace/prefix.

## Changes
* New: `lib/srs_id_manager.rb`
  * `SRSIdManager.next_id("BR")` → `"BR-1"` (increments + persists)
  * `last_number`, `set_last` (for future bootstrapping from manually assigned IDs), `ensure_ids_file`
  * Handles all listed prefixes + dynamic new ones
  * Case-insensitive prefix normalization
* New: `lib/templates/ids-template.yml` (seeds 0 for BR, TS, BC, TC, DIAG, BGT, TGT, ADR, BDR, REF)
* `lib/srs_initialization.rb`: copy + `mv` into `.srsgem/ids.yml` on `srsgem init` (exactly parallel to build-number)
* `lib/srs_builder.rb`: require + `SRSIdManager.ensure_ids_file` during build (graceful for old projects + prepares reuse)
* Minor: comment in `config.yml` template + test updates in `srs_init_tests.rb`

## API (ready for #47 / #46)
```ruby
SRSIdManager.next_id("BR")     # "BR-1", stores 1
SRSIdManager.last_number("TS") # 0 or current
SRSIdManager.set_last("ADR", 5) # for scanning existing files later
```

## Testing
* New unit test exercising the full manager inside a temp SRS project
* Manual/isolated verification of persistence, formatting, set_last, dynamic prefixes all pass
* Init simulation confirms `ids.yml` lands correctly in `.srsgem/`

## Relation to other issues
This unblocks:
- #47 (`srsgem ids assign`)
- #46 (builder integration + auto assign)
- #48 (config)
- #39 (once convention is set, assigner will use this for "next")
- #43, #44, etc.

Next logical steps after this (per prior discussion): #33 (recursive scan) + #39 (convention) + #48.

Closes #41.