### PR TITLE
Fix srsgem lint crash (issue #52)

### DIFF
--- a/lib/srs_initialization.rb
+++ b/lib/srs_initialization.rb
@@ -8,6 +8,13 @@ require_relative 'srsgem_project'
 class SRSInitialization
   ADR_STATUS_FOLDERS = %w[proposed accepted deprecated superseded].freeze
 
+  # Directories expected to exist in an SRS source project for verbiage and
+  # other structured content. Used by SRSGemLinter to detect missing structure.
+  # (See issue #52)
+  DIR_SUBPATHS = {
+    "ADRs" => "ADRs"
+  }.freeze
+
   STARTER_ADR_FILENAME = 'ADR-001-[title].md'
 
   STARTER_ADR_CONTENT = <<~MARKDOWN

--- a/lib/srsgem_linter.rb
+++ b/lib/srsgem_linter.rb
@@ -1,4 +1,5 @@
 require_relative 'srs_initialization'
+require_relative 'srsgem_project'
 
 # Helps ensure SRS source directories have all that's needed to build
 # an SRS using SRSGem. Also checks for system dependencies.
@@ -12,6 +13,9 @@ class SRSGemLinter
     ruby_version_cmd_output = %x(ruby --version)
     if "#{ruby_version_cmd_output}".include? "ruby"
       puts "#{PASSED} ruby installed"
+    else
+      puts "#{FAILED} ruby not found."
+      return "Ruby is required to run srsgem."
     end
     OK
   end
@@ -28,8 +32,8 @@ class SRSGemLinter
   end
 
   def self.check_plantuml
-    pandoc_version_cmd_output = %x(plantuml -version)
-    if "#{pandoc_version_cmd_output}".include? "PlantUML version"
+    plantuml_version_cmd_output = %x(plantuml -version)
+    if "#{plantuml_version_cmd_output}".include? "PlantUML version"
       puts "#{PASSED} PlantUML installed"
     else
       puts "#{FAILED} PlantUML not found."
@@ -41,41 +45,86 @@ class SRSGemLinter
   def self.check_srs_verbiage_source
     error_message = ''
     puts 'Checking directory structure of current folder...'
+    missing = []
     SRSInitialization::DIR_SUBPATHS.each do |key, path|
       if !File.directory?(path)
-        puts "#{FAILED} directory '#{path}'' missing..."
+        puts "#{FAILED} directory '#{path}' missing..."
+        missing << path
       end
     end
+    if missing.any?
+      return "Missing directories: #{missing.join(', ')} (run srsgem init to set up structure)."
+    end
+    puts "#{PASSED} directory structure looks good"
     OK
   end
 
   def self.check_srs_diagram_source
-    # TODO: complete this lint
+    # Check for PlantUML source files (see issue #52)
+    puml_files = Dir.glob("*.puml")
+    if puml_files.empty?
+      puts "#{FAILED} no PlantUML source files (*.puml) found"
+      return "Add .puml diagram files (they will be converted to SVG on build)."
+    end
+    puts "#{PASSED} found #{puml_files.size} PlantUML diagram source file(s)"
     OK
   end
 
   def self.check_pandoc_required_files
-    # TODO: complete this lint
+    # Basic check for files Pandoc will need (see issue #52)
+    required = ["README.md", "srs.css"]
+    missing = required.select { |f| !File.exist?(f) }
+    if missing.any?
+      puts "#{FAILED} missing Pandoc input files: #{missing.join(', ')}"
+      return "Ensure README.md and CSS are present (created by init)."
+    end
+    puts "#{PASSED} basic Pandoc input files present"
     OK
   end
 
   def self.check_for_readme_file
-    # TODO: complete this lint
+    # Check for README (see issue #52)
+    if File.exist?("README.md") || File.exist?("README.markdown")
+      puts "#{PASSED} README file present"
+    else
+      puts "#{FAILED} README.md (or .markdown) is missing"
+      return "A README file is required for the SRS project."
+    end
     OK
   end
 
   def self.check_for_css_file
-    # TODO: complete this lint
+    # Check for stylesheet (see issue #52)
+    if File.exist?("srs.css")
+      puts "#{PASSED} srs.css present"
+    else
+      puts "#{FAILED} srs.css is missing"
+      return "CSS file is needed for styled output (copied by init as srs.css)."
+    end
     OK
   end
 
   def self.check_for_build_number_tracker
-    # TODO: complete this lint
+    # Check .srsgem/build-number.yml (see issue #52)
+    path = SRSGemProject.file_path("build-number.yml")
+    if File.exist?(path)
+      puts "#{PASSED} build-number.yml tracker present in .srsgem/"
+    else
+      puts "#{FAILED} build-number.yml missing"
+      return "Run srsgem init or ensure .srsgem/build-number.yml exists."
+    end
     OK
   end
 
   def self.check_for_build_log
-    # TODO: complete this lint
+    # Check .srsgem/build.log (see issue #52)
+    path = SRSGemProject.file_path("build.log")
+    if File.exist?(path)
+      puts "#{PASSED} build.log present in .srsgem/"
+    else
+      puts "#{FAILED} build.log missing"
+      return "Run srsgem init or ensure .srsgem/build.log exists."
+    end
     OK
   end
 


### PR DESCRIPTION
## Summary
Fixes the immediate crash when running `srsgem lint` (GitHub issue #52).

## Changes
- Define the missing `DIR_SUBPATHS` in `SRSInitialization` (was causing `NameError` in `check_srs_verbiage_source`).
- Fix variable name bug in `check_plantuml`.
- Implement several previously stubbed TODO checks so the linter is now functional:
  - Diagram sources (.puml)
  - Pandoc required files
  - README
  - CSS
  - Build number tracker
  - Build log
- Make checks return proper error messages and print status consistently.
- Improve `check_ruby_version` and `check_srs_verbiage_source` to report failures.

## Testing
- `srsgem init` + `srsgem lint` now completes without error.
- Reports ✓ for present items and X + messages for missing (e.g. PlantUML when not installed).
- References issue #52.

Closes #52